### PR TITLE
21 get articles with total count

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -271,6 +271,15 @@ describe("GET /api/articles", () => {
         expect(body.total_count).toBe(13);
       });
   });
+  test("200: Responds with the last articles and total_count property when page (p) query is 2 and total_count is not divisible by 10", () => {
+    return request(app)
+      .get("/api/articles?p=2")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.articles).toHaveLength(3);
+        expect(body.total_count).toBe(13);
+      });
+  });
   test("200: Responds with the first x articles and total_count property when p is 1 and limit is x", () => {
     return request(app)
       .get("/api/articles?p=1&limit=3")

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -39,7 +39,7 @@ exports.getArticles = (req, res, next) => {
       const articles = promiseArr[0];
       const total_count = promiseArr[1];
 
-      if (p > total_count / (limit ? limit : 10)) {
+      if (p > total_count || p > (limit ? limit : 10)) {
         return Promise.reject({ status: 404, msg: "Not Found" });
       }
 


### PR DESCRIPTION
While implementing pagination of articles in the front-end of the app, I came across a bug that prevented the API from returning the last possible page of articles. I had not initially tested for this, so I added a test and corrected the error in the articles controller.